### PR TITLE
Update Leanplum SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,5 +21,5 @@ repositories {
     maven { url 'https://repo.leanplum.com' }
 }
 dependencies {
-    api 'com.leanplum:Leanplum:3.0.1'
+    api 'com.leanplum:Leanplum:3+'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,5 +21,5 @@ repositories {
     maven { url 'https://repo.leanplum.com' }
 }
 dependencies {
-    api 'com.leanplum:Leanplum:3+'
+    api 'com.leanplum:Leanplum:3.0.2'
 }


### PR DESCRIPTION
Leanplum version 3.0.1 contained a bug that prevented compiling with Java 8. This was patched in 3.0.2 and included in mParticle SDK version 4.17.2 but not included in v5+