### PR TITLE
Upgrade to 4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ This repository contains the [Leanplum](https://www.leanplum.com/) integration f
 3. Follow the mParticle Android SDK [quick-start](https://github.com/mParticle/mparticle-android-sdk), then rebuild and launch your app, and verify that you see `"Leanplum detected"` in the output of `adb logcat`.
 4. Reference mParticle's integration docs below to enable the integration.
 
+### GCM Compatibility
+
+Leanplum is deprecating GCM support, but it is still available. While we recommend migrating to FCM, if your application requires GCM, take the following steps:
+
+1. Exclude the FCM transient dependency in the leanplum kit
+
+    ```groovy
+    dependencies {
+            implementation ('com.mparticle:android-leanplum-kit:5.5.0') {
+                    exclude module: 'leanplum-fcm'
+            }
+            implementation 'com.leanplum:leanplum-gcm:4.0.0'
+        }
+    ```
 ### Documentation
 
 [Leanplum integration](http://docs.mparticle.com/?java#leanplum)

--- a/build.gradle
+++ b/build.gradle
@@ -21,5 +21,5 @@ repositories {
     maven { url 'https://repo.leanplum.com' }
 }
 dependencies {
-    api 'com.leanplum:Leanplum:3.0.1'
+    api 'com.leanplum:leanplum-fcm:4.1.1'
 }

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,23 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.mparticle.kits.leanplum" >
-    <application>
-    <service
-        android:name="com.leanplum.LeanplumPushListenerService"
-        android:exported="false" >
-        <intent-filter>
-            <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-        </intent-filter>
-    </service>
-
-    <service android:name="com.leanplum.LeanplumLocalPushListenerService" />
-
-    <service android:name="com.leanplum.LeanplumPushRegistrationService" />
-
-    <service
-        android:name="com.leanplum.LeanplumPushInstanceIDService"
-        android:exported="false">
-        <intent-filter>
-            <action android:name="com.google.android.gms.iid.InstanceID" />
-        </intent-filter>
-    </service>
-    </application>
 </manifest>


### PR DESCRIPTION
- use leanplum-fcm sdk by default
- add README instructions manually remove leanplum-fcm and continue using leanplum-gcm
- remove unnecessary AndroidManifest tags

Leanplum set this migration up to be pretty easy. We still gate access to the few code paths that are `gcm` specific using the `disableFirebase` boolean, but luckily we don't need to do any `provided` stuff to handle both cases. In one instance, registering the `LeanplumPushListenerService`, all we need is a generic `Class` reference, and the other, setting `GcmSenderId`/`GcmRegisrationId`, Leanplum does their own reflection in their base Push Service class. Still want to avoid calling the method unnecessarily, since it prints a pretty ugly error log