### PR TITLE
fix: Remove usage of deprecated isAndroidIdDisabled()

### DIFF
--- a/src/main/java/com/mparticle/kits/LeanplumKit.java
+++ b/src/main/java/com/mparticle/kits/LeanplumKit.java
@@ -278,7 +278,7 @@ public class LeanplumKit extends KitIntegration implements KitIntegration.UserAt
     }
 
     void setDeviceIdType(String deviceIdType) {
-        if (DEVICE_ID_TYPE_ANDROID_ID.equals(deviceIdType) && !MParticle.isAndroidIdDisabled()) {
+        if (DEVICE_ID_TYPE_ANDROID_ID.equals(deviceIdType) && MParticle.isAndroidIdEnabled()) {
             Leanplum.setDeviceIdMode(LeanplumDeviceIdMode.ANDROID_ID);
         } else if (DEVICE_ID_TYPE_GOOGLE_AD_ID.equals(deviceIdType)) {
             Leanplum.setDeviceIdMode(LeanplumDeviceIdMode.ADVERTISING_ID);

--- a/src/test/java/com/mparticle/MockMParticle.java
+++ b/src/test/java/com/mparticle/MockMParticle.java
@@ -12,7 +12,7 @@ public class MockMParticle extends MParticle {
         }
 
         public void setAndroidIdDisabled(boolean disabled) {
-            sAndroidIdDisabled = disabled;
+            sAndroidIdEnabled = !disabled;
         }
 
 }


### PR DESCRIPTION
# Summary

Remove usage of deprecated isAndroidIdDisabled() and replace with the inverse isAndroidEnabled()
