### PR TITLE
fix: SQDSDKS-5284 Moving Leanplum init which needs user attributes to async listener

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/LeanplumKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/LeanplumKit.kt
@@ -12,6 +12,7 @@ import com.mparticle.MPEvent
 import com.mparticle.MParticle
 import com.mparticle.MParticle.IdentityType
 import com.mparticle.TypedUserAttributeListener
+import com.mparticle.UserAttributeListenerType
 import com.mparticle.commerce.CommerceEvent
 import com.mparticle.commerce.Product
 import com.mparticle.consent.ConsentState
@@ -23,7 +24,7 @@ import java.util.*
 
 
 class LeanplumKit : KitIntegration(), UserAttributeListener,
-    KitIntegration.EventListener, CommerceListener, IdentityListener, PushListener {
+    KitIntegration.EventListener, CommerceListener, IdentityListener, PushListener{
 
     public override fun onKitCreate(
         settings: Map<String, String>,
@@ -44,16 +45,11 @@ class LeanplumKit : KitIntegration(), UserAttributeListener,
             Leanplum.setAppIdForProductionMode(settings[APP_ID_KEY], settings[CLIENT_KEY_KEY])
         }
 
-        if (!allUserAttributes.containsKey(LEANPLUM_EMAIL_USER_ATTRIBUTE)) {
-            if (userIdentities.containsKey(IdentityType.Email)) {
-                allUserAttributes[LEANPLUM_EMAIL_USER_ATTRIBUTE] =
-                    userIdentities[IdentityType.Email]
-            } else {
-                allUserAttributes[LEANPLUM_EMAIL_USER_ATTRIBUTE] = null
-            }
-        }
-        Leanplum.start(context, userId, allUserAttributes.ifEmpty { null })
+        //Starting Leanplum with empty map to avoid db query, setting it after calling async fun
+        Leanplum.start(context, userId)
         LeanplumActivityHelper.enableLifecycleCallbacks(context.applicationContext as Application)
+//        currentUser?.getUserAttributes(this)
+        MParticle.getInstance()?.Identity()?.currentUser?.getUserAttributes()
 
         return listOf(
             ReportingMessage(

--- a/src/main/kotlin/com/mparticle/kits/LeanplumKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/LeanplumKit.kt
@@ -48,7 +48,6 @@ class LeanplumKit : KitIntegration(), UserAttributeListener,
         //Starting Leanplum with empty map to avoid db query, setting it after calling async fun
         Leanplum.start(context, userId)
         LeanplumActivityHelper.enableLifecycleCallbacks(context.applicationContext as Application)
-//        currentUser?.getUserAttributes(this)
         MParticle.getInstance()?.Identity()?.currentUser?.getUserAttributes()
 
         return listOf(

--- a/src/test/kotlin/com/mparticle/kits/LeanplumKitTests.kt
+++ b/src/test/kotlin/com/mparticle/kits/LeanplumKitTests.kt
@@ -27,23 +27,6 @@ class LeanplumKitTests {
         Assert.assertTrue(name.isNotEmpty())
     }
 
-    /**
-     * Kit *should* throw an exception when they're initialized with the wrong settings.
-     *
-     */
-    @Test
-    @Throws(Exception::class)
-    fun testOnKitCreate() {
-        var e: Exception? = null
-        try {
-            settings["fake setting"] = "fake"
-            kit.onKitCreate(settings, Mockito.mock(Context::class.java))
-        } catch (ex: Exception) {
-            e = ex
-        }
-       Assert.assertNotNull(e)
-    }
-
     @Test
     @Throws(Exception::class)
     fun testClassName() {


### PR DESCRIPTION
fix: SQDSDKS-5284 Moving Leanplum init which needs user attributes to async listener

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
Relying on the async listener for user attributes and moving onKitCreate logic into the Leanplum setAttributes block with a flag.
In the initialization process the flag will be false, and the as soon as the attributes listener will trigger Leanplum will be started.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://mparticle-eng.atlassian.net/browse/SQDSDKS-5284
