### PR TITLE
fix: SQDSDKS-5284 Moving Leanplum init async

### DIFF
--- a/src/test/kotlin/com/mparticle/kits/LeanplumKitTests.kt
+++ b/src/test/kotlin/com/mparticle/kits/LeanplumKitTests.kt
@@ -27,23 +27,6 @@ class LeanplumKitTests {
         Assert.assertTrue(name.isNotEmpty())
     }
 
-    /**
-     * Kit *should* throw an exception when they're initialized with the wrong settings.
-     *
-     */
-    @Test
-    @Throws(Exception::class)
-    fun testOnKitCreate() {
-        var e: Exception? = null
-        try {
-            settings["fake setting"] = "fake"
-            kit.onKitCreate(settings, Mockito.mock(Context::class.java))
-        } catch (ex: Exception) {
-            e = ex
-        }
-       Assert.assertNotNull(e)
-    }
-
     @Test
     @Throws(Exception::class)
     fun testClassName() {


### PR DESCRIPTION
SQDSDKS-5284 Moving Leanplum init which needs user attributes to async listener

* Relying on the async listener for user attributes and moving onKitCreate logic into the Leanplum setAttributes block with a flag. In the initialization process the flag will be false, and the as soon as the attributes listener will trigger Leanplum will be started.

* Changes due to Sam's comments

* comments

* Changes

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - {provide a thorough description of the changes}

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
